### PR TITLE
[#163138018] Integrate test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - pip install coveralls
 
 script:
-  - py.test
+  - py.test --cov
 
 after_success:
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 language: python
+
 python:
   - "3.5.2"
+
+before_install:
+    - pip install pytest pytest-cov
+    - pip install coveralls
+
 script:
   - py.test
-  
+
+after_success:
+    - coveralls

--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ Optional Features
 3. User can reset password. 
  
   [![Build Status](https://travis-ci.org/da-tinker/questioner.svg?branch=develop)](https://travis-ci.org/da-tinker/questioner)
+
+[![Coverage Status](https://coveralls.io/repos/github/da-tinker/questioner/badge.svg?branch=develop)](https://coveralls.io/github/da-tinker>/questioner?branch=develop)

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Optional Features
  
   [![Build Status](https://travis-ci.org/da-tinker/questioner.svg?branch=develop)](https://travis-ci.org/da-tinker/questioner)
 
-[![Coverage Status](https://coveralls.io/repos/github/da-tinker/questioner/badge.svg?branch=develop)](https://coveralls.io/github/da-tinker>/questioner?branch=develop)
+[![Coverage Status](https://coveralls.io/repos/github/da-tinker/questioner/badge.svg?branch=develop)](https://coveralls.io/github/da-tinker/questioner?branch=develop)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Optional Features
 2. Admin can add tags to a meetup record. 
 3. User can reset password. 
  
-  [![Build Status](https://travis-ci.org/da-tinker/questioner.svg?branch=develop)](https://travis-ci.org/da-tinker/questioner)
+[![Build Status](https://travis-ci.org/da-tinker/questioner.svg?branch=develop)](https://travis-ci.org/da-tinker/questioner)
 
 [![Coverage Status](https://coveralls.io/repos/github/da-tinker/questioner/badge.svg?branch=develop)](https://coveralls.io/github/da-tinker/questioner?branch=develop)
+
+[![Maintainability](https://api.codeclimate.com/v1/badges/2cada0d526a4ef023891/maintainability)](https://codeclimate.com/github/da-tinker/questioner/maintainability)
+
+[![Test Coverage](https://api.codeclimate.com/v1/badges/2cada0d526a4ef023891/test_coverage)](https://codeclimate.com/github/da-tinker/questioner/test_coverage)


### PR DESCRIPTION
**What does this PR do?**
1. Integrates test coverage reporting with Coveralls
2. Adds CI badges to README.md

**Description of Task to be completed**
1. Update travis config to run coveralls
2. Add badges to README.md

**Screenshots**
![test_coverage_start](https://user-images.githubusercontent.com/45802848/51011009-c5736680-1567-11e9-9018-90004d9ee735.png)
![test_coverage_coverall_1](https://user-images.githubusercontent.com/45802848/51011417-8219f780-1569-11e9-99da-4396130f9a3e.png)
![test_coverage_coverall_2](https://user-images.githubusercontent.com/45802848/51011430-90681380-1569-11e9-9182-ee45e010ed16.png)

**What are the relevant Pivotal Tracker Story IDs?**
[#163138018]